### PR TITLE
Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,20 @@
 # QuickPID   [![arduino-library-badge](https://www.ardu-badge.com/badge/QuickPID.svg?)](https://www.ardu-badge.com/QuickPID)
 
-QuickPID is a fast fixed/floating point implementation of the Arduino PID library with built-in [AutoTune](https://github.com/Dlloydev/QuickPID/wiki/AutoTune) class as a dynamic object  to reduce memory if not used, thanks to contributions by [gnalbandian (Gonzalo)](https://github.com/gnalbandian). This controller can automatically determine and set parameters `Kp, Ki, Kd`. Additionally the Ultimate Gain `Ku`, Ultimate Period `Tu`, Dead Time `td` and determine how easy the process is to control. There are 10 tuning rules available to choose from. Also available is a POn setting that controls the mix of Proportional on Error to Proportional on Measurement.  
+QuickPID is a fast fixed/floating point implementation of the Arduino PID library with built-in [AutoTune](https://github.com/Dlloydev/QuickPID/wiki/AutoTune) class as a dynamic object  to reduce memory if not used, thanks to contributions by [gnalbandian (Gonzalo)](https://github.com/gnalbandian). This controller can automatically determine and set parameters `Kp, Ki, Kd`. Additionally the Ultimate Gain `Ku`, Ultimate Period `Tu`, Dead Time `td` and determine how easy the process is to control. There are 10 tuning rules available to choose from. Also available is a POn setting that controls the mix of Proportional on Error to Proportional on Measurement. 
 
 ### About
 
-This PID controller provides a shortened *read-compute-write* cycle by using a reduced PID algorithm, taking advantage of fixed point math and using a fast analog read function. The `Ki` and `Kd` are scaled by time (µs) and the new `kpi` and `kpd` parameters are calculated in the `SetTunings()` function resulting in only two multiply operations required in `Compute()`.
+This PID controller provides a shortened *read-compute-write* cycle by taking advantage of fixed point math and using a fast analog read function.
 
 ### Features
 
-Development began with a fork of the Arduino PID Library. Modifications and new features have been added as described in the change log and below:
-
-- Quicker hybrid fixed/floating point math, efficient PID algorithm and micros() timing resolution.
-- Built-in `AutoTunePID` class as a dynamic object. AutoTune automatically determines and applies `Kp`, `Ki` and `Kd` tuning parameters and has 10 tuning rules to choose from.
-- Variable `POn` parameter controls the setpoint weighting and mix of Proportional on Error to Proportional on Measurement.
-- Includes [analogWrite](https://github.com/Dlloydev/ESP32-ESP32S2-AnalogWrite) for ESP32 boards.
-
-### Performance (16MHz ATmega328P)
-
-| `Compute()` | Kp   | Ki   | Kd   | Step Time (µS) |
-| :---------- | ---- | ---- | ---- | -------------- |
-| QuickPID    | 2.0  | 5.0  | 1.0  | 72             |
-| Arduino PID | 2.0  | 5.0  | 1.0  | 104            |
+Development began with a fork of the Arduino PID Library. Modifications and new features have been added as described in the change log.
 
 ### [AutoTune RC Filter](https://github.com/Dlloydev/QuickPID/wiki/AutoTune_RC_Filter)
 
 This example allows you to experiment with the AutoTunePID class, various tuning rules and the POn control using ADC and PWM with RC filter. It automatically determines and sets the tuning parameters and works with both DIRECT and REVERSE acting controllers.
 
 #### [QuickPID WiKi ...](https://github.com/Dlloydev/QuickPID/wiki)
-
-### Simplified PID Algorithm
-
-```c++
-outputSum += (kpi * error) - (kpd * dInput);
-```
-
-The `kpi` and `kpd` parameters are calculated in the `SetTunings()` function. This results in a simple and fast algorithm with only two multiply operations required. The gains for `error` (`kpi`) and measurement `dInput` (`kpd`) are calculated as follows:
-
-```c++
- kpi = kp * pOn + ki;
- kpd = kp * (1 - pOn) + kd;
-```
 
 ### Direct and Reverse Controller Action
 
@@ -79,7 +54,7 @@ This function contains the PID algorithm and it should be called once every loop
 
 #### [AutoTune](https://github.com/Dlloydev/QuickPID/wiki/AutoTune)
 
-For use of AutoTune, refer to the examples `AutoTune_Filter_DIRECT.ino` and `AutoTune_Filter_REVERSE.ino`
+For use of AutoTune, refer to the examples [AutoTune_Filter_DIRECT.ino](https://github.com/Dlloydev/QuickPID/blob/master/examples/AutoTune_Filter_DIRECT/AutoTune_Filter_DIRECT.ino) and [AutoTune_Filter_REVERSE.ino](https://github.com/Dlloydev/QuickPID/blob/master/examples/AutoTune_Filter_REVERSE/AutoTune_Filter_REVERSE.ino)
 
 #### SetTunings
 
@@ -163,6 +138,12 @@ A faster configuration of `analogRead()`where a preset of 32 is used.  If the ar
 Use this link for reference. Note that if you're using QuickPID, there's no need to install the AnalogWrite library as this feature is already included.
 
 #### Change Log
+
+#### Version 2.3.1
+
+- Resolved `Kp` windup  as noted in issue #6. Algorithm reverts to upstream library, but with fixed point math option and newer controller direction method maintained.
+- Updated AutoTune examples and documentation.
+- Default AutoTune  `outputStep` value in examples (and documentation) is now 5.
 
 #### Version 2.3.0
 

--- a/examples/AutoTune_Filter_DIRECT/AutoTune_Filter_DIRECT.ino
+++ b/examples/AutoTune_Filter_DIRECT/AutoTune_Filter_DIRECT.ino
@@ -74,7 +74,7 @@ void loop() {
     _myPID.Compute();
     analogWrite(outputPin, Output);
   }
-  //delay(1); // adjust loop speed
+  delay(1); // adjust loop speed
 }
 
 float avg(int inputVal) {

--- a/examples/AutoTune_Filter_DIRECT/AutoTune_Filter_DIRECT.ino
+++ b/examples/AutoTune_Filter_DIRECT/AutoTune_Filter_DIRECT.ino
@@ -1,6 +1,5 @@
 /******************************************************************************
    AutoTune Filter DIRECT Example
-   Reference: https://github.com/Dlloydev/QuickPID/wiki/AutoTune
    Circuit: https://github.com/Dlloydev/QuickPID/wiki/AutoTune_RC_Filter
  ******************************************************************************/
 
@@ -15,8 +14,7 @@ const int outputMin = 0;
 float POn = 1.0;          // mix of PonE to PonM (0.0-1.0)
 
 bool printOrPlotter = 0;  // on(1) monitor, off(0) plotter
-byte tuningRule = 1;      // see reference link
-byte outputStep = 1;
+byte outputStep = 5;
 byte hysteresis = 1;
 int setpoint = 341;       // 1/3 of 10-bit ADC range for symetrical waveform
 int output = 85;          // 1/3 of 8-bit PWM range for symetrical waveform
@@ -34,7 +32,18 @@ void setup() {
     Serial.println(F("AutoTune test exceeds outMax limit. Check output, hysteresis and outputStep values"));
     while (1);
   }
+  // Select one, reference: https://github.com/Dlloydev/QuickPID/wiki
+  //_myPID.AutoTune(tuningMethod::ZIEGLER_NICHOLS_PI);
   _myPID.AutoTune(tuningMethod::ZIEGLER_NICHOLS_PID);
+  //_myPID.AutoTune(tuningMethod::TYREUS_LUYBEN_PI);
+  //_myPID.AutoTune(tuningMethod::TYREUS_LUYBEN_PID);
+  //_myPID.AutoTune(tuningMethod::CIANCONE_MARLIN_PI);
+  //_myPID.AutoTune(tuningMethod::CIANCONE_MARLIN_PID);
+  //_myPID.AutoTune(tuningMethod::AMIGOF_PID);
+  //_myPID.AutoTune(tuningMethod::PESSEN_INTEGRAL_PID);
+  //_myPID.AutoTune(tuningMethod::SOME_OVERSHOOT_PID);
+  //_myPID.AutoTune(tuningMethod::NO_OVERSHOOT_PID);
+
   _myPID.autoTune->autoTuneConfig(outputStep, hysteresis, setpoint, output, QuickPID::DIRECT, printOrPlotter);
 }
 

--- a/examples/AutoTune_Filter_REVERSE/AutoTune_Filter_REVERSE.ino
+++ b/examples/AutoTune_Filter_REVERSE/AutoTune_Filter_REVERSE.ino
@@ -1,6 +1,5 @@
 /******************************************************************************
    AutoTune Filter REVERSE Example
-   Reference: https://github.com/Dlloydev/QuickPID/wiki/AutoTune
    Circuit: https://github.com/Dlloydev/QuickPID/wiki/AutoTune_RC_Filter
  ******************************************************************************/
 
@@ -16,8 +15,7 @@ const int outputMin = 0;
 float POn = 1.0;          // mix of PonE to PonM (0.0-1.0)
 
 bool printOrPlotter = 0;  // on(1) monitor, off(0) plotter
-byte tuningRule = 1;      // see reference link
-byte outputStep = 1;
+byte outputStep = 5;
 byte hysteresis = 1;
 int setpoint = 341;       // 1/3 of 10-bit ADC range for symetrical waveform
 int output = 85;          // 1/3 of 8-bit PWM range for symetrical waveform
@@ -35,7 +33,18 @@ void setup() {
     Serial.println(F("AutoTune test exceeds outMax limit. Check output, hysteresis and outputStep values"));
     while (1);
   }
+  // Select one, reference: https://github.com/Dlloydev/QuickPID/wiki
+  //_myPID.AutoTune(tuningMethod::ZIEGLER_NICHOLS_PI);
   _myPID.AutoTune(tuningMethod::ZIEGLER_NICHOLS_PID);
+  //_myPID.AutoTune(tuningMethod::TYREUS_LUYBEN_PI);
+  //_myPID.AutoTune(tuningMethod::TYREUS_LUYBEN_PID);
+  //_myPID.AutoTune(tuningMethod::CIANCONE_MARLIN_PI);
+  //_myPID.AutoTune(tuningMethod::CIANCONE_MARLIN_PID);
+  //_myPID.AutoTune(tuningMethod::AMIGOF_PID);
+  //_myPID.AutoTune(tuningMethod::PESSEN_INTEGRAL_PID);
+  //_myPID.AutoTune(tuningMethod::SOME_OVERSHOOT_PID);
+  //_myPID.AutoTune(tuningMethod::NO_OVERSHOOT_PID);
+
   _myPID.autoTune->autoTuneConfig(outputStep, hysteresis, inputMax - setpoint, output, QuickPID::REVERSE, printOrPlotter);
 }
 

--- a/examples/AutoTune_Filter_REVERSE/AutoTune_Filter_REVERSE.ino
+++ b/examples/AutoTune_Filter_REVERSE/AutoTune_Filter_REVERSE.ino
@@ -75,7 +75,7 @@ void loop() {
     _myPID.Compute();
     analogWrite(outputPin, Output);
   }
-  //delay(1); // adjust loop speed
+  delay(1); // adjust loop speed
 }
 
 float avg(int inputVal) {

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "keywords": "PID, controller, signal",
   "description": "A fast fixed/floating point PID controller with AutoTune and 10 tuning rules to choose from. This controller can automatically determine and set tuning parameters. Compatible with most Arduino and ESP32 boards.",
   "license": "MIT",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "url": "https://github.com/Dlloydev/QuickPID",
   "include": "QuickPID",
   "authors":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=QuickPID
-version=2.3.0
+version=2.3.1
 author=David Lloyd
 maintainer=David Lloyd <dlloydev@testcor.ca>
 sentence=A fast fixed/floating point PID controller with AutoTune and 10 tuning rules to choose from.

--- a/src/QuickPID.cpp
+++ b/src/QuickPID.cpp
@@ -248,6 +248,7 @@ byte AutoTunePID::autoTuneLoop()
       break;
     case STABILIZING:
       if (_printOrPlotter == 1) Serial.print(F("Stabilizing →"));
+      _t0 = millis();
       _peakHigh = _atSetpoint;
       _peakLow = _atSetpoint;
       (!_direction) ? *_output = 0 : *_output = _atOutput + _outputStep + 5;
@@ -255,7 +256,10 @@ byte AutoTunePID::autoTuneLoop()
       return AUTOTUNE;
       break;
     case COARSE: // coarse adjust
-      delay(2000);
+      if (millis() - _t0 < 2000) {
+        return AUTOTUNE;
+        break;
+      }
       if (*_input < (_atSetpoint - _hysteresis)) {
         (!_direction) ? *_output = _atOutput + _outputStep + 5 : *_output = _atOutput - _outputStep - 5;
         _autoTuneStage = FINE;

--- a/src/QuickPID.cpp
+++ b/src/QuickPID.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************************
-   QuickPID Library for Arduino - Version 2.3.0
+   QuickPID Library for Arduino - Version 2.3.1
    by dlloydev https://github.com/Dlloydev/QuickPID
    Based on the Arduino PID Library and work on AutoTunePID class
    by gnalbandian (Gonzalo). Licensed under the MIT License
@@ -53,7 +53,7 @@ bool QuickPID::Compute() {
   uint32_t now = micros();
   uint32_t timeChange = (now - lastTime);
 
-  if (timeChange >= sampleTimeUs) {  // Compute the working error variables
+  if (timeChange >= sampleTimeUs) {  // compute the working errors
     float input = *myInput;
     float dInput = input - lastInput;
     error = *mySetpoint - input;
@@ -61,12 +61,27 @@ bool QuickPID::Compute() {
       error = -error;
       dInput = -dInput;
     }
-    if (kpi < 31 && kpd < 31) outputSum += FX_MUL(FL_FX(kpi) , error) - FX_MUL(FL_FX(kpd), (int)dInput); // fixed point
-    else outputSum += (kpi * error) - (kpd * dInput); // floating-point
+    // add integral error amount
+    if (ki < 31) outputSum += FX_MUL(FL_FX(ki), error);
+    else outputSum += (ki * error);
 
+    // proportional on measurement amount
+    if (kpm < 31) outputSum -= FX_MUL(FL_FX(kpm), dInput);
+    else outputSum -= (kpm * dInput);
     outputSum = CONSTRAIN(outputSum, outMin, outMax);
-    *myOutput = outputSum;
 
+    // proportional on error amount
+    float output;
+    if (kpe < 31) output = FX_MUL(FL_FX(kpe), error);
+    else output = (kpe * error);
+
+    // derivative amount
+    if (kd < 31) output += outputSum - FX_MUL(FL_FX(kd), dInput);
+    else output += outputSum - kd * dInput;
+    output = CONSTRAIN(output, outMin, outMax);
+    *myOutput = output;
+
+    // remember some variables for next time
     lastInput = input;
     lastTime = now;
     return true;
@@ -88,8 +103,8 @@ void QuickPID::SetTunings(float Kp, float Ki, float Kd, float POn = 1) {
   kp = Kp;
   ki = Ki * SampleTimeSec;
   kd = Kd / SampleTimeSec;
-  kpi = (kp * pOn) + ki;
-  kpd = (kp * (1 - pOn)) + kd;
+  kpe = kp * pOn;
+  kpm = kp * (1 - pOn);
 }
 
 /* SetTunings(...)*************************************************************
@@ -211,7 +226,6 @@ AutoTunePID::AutoTunePID(float *input, float *output, tuningMethod tuningRule)
 
 void AutoTunePID::reset()
 {
-
   _t0 = 0;
   _t1 = 0;
   _t2 = 0;

--- a/src/QuickPID.h
+++ b/src/QuickPID.h
@@ -133,8 +133,8 @@ class QuickPID {
     float kp;           // (P)roportional Tuning Parameter
     float ki;           // (I)ntegral Tuning Parameter
     float kd;           // (D)erivative Tuning Parameter
-    float kpi;          // proportional on error amount
-    float kpd;          // proportional on measurement amount
+    float kpe;          // proportional on error amount
+    float kpm;          // proportional on measurement amount
 
     float *myInput;     // Pointers to the Input, Output, and Setpoint variables. This creates a
     float *myOutput;    // hard link between the variables and the PID, freeing the user from having


### PR DESCRIPTION
- Resolved `Kp` windup  as noted in issue #6. Algorithm reverts to upstream library, but with fixed point math option and newer controller direction method maintained.
- Updated AutoTune examples and documentation.