### PR TITLE
Avoid double promotion in QuickPID::Compute()

### DIFF
--- a/src/QuickPID.cpp
+++ b/src/QuickPID.cpp
@@ -83,8 +83,8 @@ bool QuickPID::Compute() {
     if (pmode == pMode::pOnError) pmTerm = 0;
     else if (pmode == pMode::pOnMeas) peTerm = 0;
     else { //pOnErrorMeas
-      peTerm *= 0.5;
-      pmTerm *= 0.5;
+      peTerm *= 0.5f;
+      pmTerm *= 0.5f;
     }
     pTerm = peTerm - pmTerm; // used by GetDterm()
     iTerm =  ki  * error;


### PR DESCRIPTION
Hello. This is a small issue I caught with the compiler option `Wdouble-promotion`. It does not matter for AVR, of course, but it does make a difference in other platforms such as Espressif.

Quote from ESP-IDF [docs](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/freertos-smp.html?highlight=double#floating-point-arithmetic):
> ESP32 does not support hardware acceleration for double precision floating point arithmetic (double). Instead double is implemented via software hence the behavioral restrictions with regards to float do not apply to double. Note that due to the lack of hardware acceleration, double operations may consume significantly larger amount of CPU time in comparison to float.