### PR TITLE
Expose outputSum for monitoring and userspace anti-windup

### DIFF
--- a/src/QuickPID.h
+++ b/src/QuickPID.h
@@ -80,6 +80,7 @@ class QuickPID {
     uint8_t GetDmode();       // dOnError (0), dOnMeas (1)
     uint8_t GetAwMode();      // iAwCondition (0, iAwClamp (1), iAwOff (2)
 
+    float outputSum;          // Internal integral sum
   private:
 
     void Initialize();
@@ -106,7 +107,7 @@ class QuickPID {
     iAwMode iawmode = iAwMode::iAwCondition;
 
     uint32_t sampleTimeUs, lastTime;
-    float outputSum, outMin, outMax, error, lastError, lastInput;
+    float outMin, outMax, error, lastError, lastInput;
 
 }; // class QuickPID
 #endif // QuickPID.h


### PR DESCRIPTION
This PR moves the outputSum variable from public to private.

While the same functionality might be provided by a GetIntegral() and SetIntegral(value) or a user-space  `myPID.SetMode(myPID.Control::manual);Output=value;myPID.SetMode(myPID.Control::automatic);` trick, moving the variable up to Public is a minimal change.

Why I think it is an important change is it helps for understanding the trickiest parts of PIDs: the behavior of the integral term.  Good explanations of the functionality of PIDs often include graphs of the behavior of the components.  Without access to the internal outputSum, it is impossible to see what is going on in the black box.

I've been experimenting with simulating a 1-D heat transfer problem controlled by a PID:

https://wokwi.com/projects/359818835102393345

<img width="619" alt="image" src="https://user-images.githubusercontent.com/2236516/226650309-7a7efc3e-ffad-4204-ad0f-fef36eb2ddca.png">

Note that it shows the exposed integral on the LCD and the time-series, which I think is very helpful for understanding the interactions of the tuning parameters.

