### PR TITLE
bug fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(
+    SRC_DIRS "src"
+    INCLUDE_DIRS "src"
+    REQUIRES arduino
+    PRIV_REQUIRES driver soc 
+)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # QuickPID   [![arduino-library-badge](https://www.ardu-badge.com/badge/QuickPID.svg?)](https://www.ardu-badge.com/QuickPID) [![PlatformIO Registry](https://badges.registry.platformio.org/packages/dlloydev/library/QuickPID.svg)](https://registry.platformio.org/packages/libraries/dlloydev/QuickPID)
-
+```
+you can use this library in esp-idf tool to program esp32 by cloning this repo into your components folder.
+then clean the build and rebuild.
+```
 QuickPID is an updated implementation of the Arduino PID library with additional features for PID control. By default, this implementation closely follows the method of processing the p,i,d terms as in the PID_v1 library except for using a more advanced anti-windup mode. Integral anti-windup can be based on conditionally using PI terms to provide some integral correction, prevent deep saturation and reduce overshoot. Anti-windup can also be based on clamping only, or it can be turned completely off. Also, the proportional term can be based on error, measurement, or both. The derivative term can be based on error or measurement.  PID controller modes include timer, which allows external timer or ISR timing control.
 
 ### Features

--- a/src/QuickPID.h
+++ b/src/QuickPID.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdint.h>
 #ifndef QuickPID_h
 #define QuickPID_h
 


### PR DESCRIPTION
Resolved the following error while building in esp-idf in commit id: "97c5a1b83815075aef9c0efcd06985d5ff5ebfd8"

```
error: 'QuickPID::Control' has not been declared
   motorPID1.SetMode(motorPID1.Control::automatic);
```